### PR TITLE
Add ExplicitHashKey on Kinesis Flusher

### DIFF
--- a/flushers/kinesis.js
+++ b/flushers/kinesis.js
@@ -17,7 +17,7 @@ class KinesisFlusher {
    *
    * @param {Function} [callback]
    * @param {Object} err
-   * @param {Object} [encodedMessage] { Data, PartitionKey }
+   * @param {Object} [encodedMessage] { Data, PartitionKey, ExplicitHashKey }
    */
   sendMessageToKinesis (callback, err, encodedMessage) {
     if (err) callback(err)
@@ -25,6 +25,7 @@ class KinesisFlusher {
     const params = {
       Data: encodedMessage.Data,
       PartitionKey: encodedMessage.PartitionKey,
+      ExplicitHashKey: encodedMessage.ExplicitHashKey,
       StreamName: this.host
     }
 
@@ -44,9 +45,15 @@ class KinesisFlusher {
   call (data, callback) {
     const kinesisMessages = data.batch.map((record) => {
       var pk = (1.0 * Math.random()).toString().replace('.', '')
+      var ehk = (1.0 * Math.random()).toString().replace('.', '')
+
+      while (ehk[0] === '0' && ehk.length > 0) {
+        ehk = ehk.substring(1)
+      }
 
       return {
         'PartitionKey': pk,
+        'ExplicitHashKey': ehk,
         'Data': JSON.stringify(record)
       }
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-node",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "The hassle-free way to integrate analytics into any Node.js application",
   "license": "MIT",
   "repository": "segmentio/analytics-node",


### PR DESCRIPTION
Adding random ExplicitHash on KPL messages.

*Known issues: Randomizing the ExplicitHashKey will make Kinesis not to distribute the load correctly. We will use this approach now since without it the KPL library does not work properly, but we may have to review this on the future.